### PR TITLE
Update version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
     }
   ],
   "require": {
-    "php": ">=5.6",
-    "illuminate/support": "5.3.x|5.4.x|5.5.x"
+    "php": "^5.6 || ^7.0",
+    "illuminate/support": "5.3.* || 5.4.* || 5.5.*"
   },
   "require-dev": {
-    "phpunit/phpunit": "~5.7",
-    "orchestra/testbench": "~3.2",
+    "phpunit/phpunit": "^5.7 || ^6.0",
+    "orchestra/testbench": "^3.2",
     "squizlabs/php_codesniffer": "^2.3"
   },
   "autoload": {


### PR DESCRIPTION
This way this package doesn't support PHP 8.0 in the future. Since we don't know if there will be any breaking changes in PHP we shouldn't allow this package to work with future versions just yet.