### PR TITLE
Prevent collapsing whitespaces inside textarea/pre

### DIFF
--- a/src/Middleware/CollapseWhitespace.php
+++ b/src/Middleware/CollapseWhitespace.php
@@ -4,17 +4,150 @@ namespace RenatoMarinho\LaravelPageSpeed\Middleware;
 
 class CollapseWhitespace extends PageSpeed
 {
+    const REPLACEMENT = [
+        "/\n([\S])/" => '$1',
+        "/\r/"       => '',
+        "/\n/"       => '',
+        "/\t/"       => '',
+        '/ +/'       => ' ',
+        '/> +</'     => '><',
+    ];
+
+    /** @var string[] */
+    private $preFounds = [];
+
+    /** @var string[] */
+    private $textareaFounds = [];
+
+    /** @var string */
+    private $key;
+
+    /**
+     * CollapseWhitespace constructor
+     */
+    public function __construct()
+    {
+        $this->key = \md5(\random_int(0, 100) . \date('d.m.Y H:i:s')).'-';
+    }
+
+    /**
+     * Apply replacement
+     *
+     * @param string $buffer
+     * @return string
+     */
     public function apply($buffer)
     {
-        $replace = [
-            "/\n([\S])/" => '$1',
-            "/\r/" => '',
-            "/\n/" => '',
-            "/\t/" => '',
-            "/ +/" => ' ',
-            "/> +</" => '><',
-        ];
+        $buffer = $this->preReplaceChange($buffer);
 
-        return $this->replace($replace, $buffer);
+        $buffer = $this->replace(self::REPLACEMENT, $buffer);
+
+        $buffer = $this->postReplaceChange($buffer);
+
+        return $buffer;
+    }
+
+    /**
+     * Perform pre-replace changes
+     *
+     * @param string $buffer
+     * @return string
+     */
+    private function preReplaceChange($buffer)
+    {
+        $buffer = $this->prepareTextArea($buffer);
+        $buffer = $this->preparePre($buffer);
+
+        return $buffer;
+    }
+
+    /**
+     * Perform post-replace changes
+     *
+     * @param string $buffer
+     * @return string
+     */
+    private function postReplaceChange($buffer)
+    {
+        $buffer = $this->recoverTextArea($buffer);
+        $buffer = $this->recoverPre($buffer);
+
+        return $buffer;
+    }
+
+    /**
+     * Cut <textarea> content to prevent minification
+     *
+     * @param string $buffer
+     * @return string
+     */
+    private function prepareTextArea($buffer)
+    {
+        \preg_match_all('#\<textarea.*\>.*\<\/textarea\>#Uis', $buffer, $foundTxt);
+
+        $this->textareaFounds = isset($foundTxt[0]) ? $foundTxt[0] : [];
+
+        return \str_replace(
+            $this->textareaFounds,
+            \array_map(function ($el) {
+                return '<textarea>'.$this->key.$el.'</textarea>';
+            }, \array_keys($this->textareaFounds)),
+            $buffer
+        );
+    }
+
+    /**
+     * Cut <pre> content to prevent minification
+     *
+     * @param string $buffer
+     * @return string
+     */
+    private function preparePre($buffer)
+    {
+        \preg_match_all('#\<pre.*\>.*\<\/pre\>#Uis', $buffer, $foundPre);
+
+        $this->preFounds = isset($foundPre[0]) ? $foundPre[0] : [];
+
+        return \str_replace(
+            $this->preFounds,
+            \array_map(function ($el) {
+                return '<pre>'.$this->key.$el.'</pre>';
+            }, \array_keys($this->preFounds)),
+            $buffer
+        );
+    }
+
+    /**
+     * Revert original <textarea> content to view
+     *
+     * @param string $buffer
+     * @return string
+     */
+    private function recoverTextArea($buffer)
+    {
+        return \str_replace(
+            \array_map(function ($el) {
+                return '<textarea>'.$this->key.$el.'</textarea>';
+            }, \array_keys($this->textareaFounds)),
+            $this->textareaFounds,
+            $buffer
+        );
+    }
+
+    /**
+     * Revert original <pre> content to view
+     *
+     * @param string $buffer
+     * @return string
+     */
+    private function recoverPre($buffer)
+    {
+        return \str_replace(
+            \array_map(function ($el) {
+                return '<pre>'.$this->key.$el.'</pre>';
+            }, \array_keys($this->preFounds)),
+            $this->preFounds,
+            $buffer
+        );
     }
 }


### PR DESCRIPTION
## Description

Middleware `CollapseWhitespaces` trim whitespaces also inside `<pre>` and `<textarea>` tags, which is not desired behavior.

## Motivation and context

I am planning to use this library for my technology blog, which has a lot of `<pre>` elements. To prevent collapsing whitespaces inside them, I added this functionality.

## How has this been tested?

[WIP]

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
