### PR TITLE
CollapseWhitespace to ignore certain HTML elements

### DIFF
--- a/src/Middleware/CollapseWhitespace.php
+++ b/src/Middleware/CollapseWhitespace.php
@@ -1,20 +1,128 @@
 <?php
 
-namespace RenatoMarinho\LaravelPageSpeed\Middleware;
+namespace App\Http\Middleware;
+
+use RenatoMarinho\LaravelPageSpeed\Middleware\PageSpeed;
 
 class CollapseWhitespace extends PageSpeed
 {
+
+    const REPLACEMENT = [
+        "/\n([\S])/" => '$1',
+        "/\r/"       => '',
+        "/\n+/"      => '',
+        "/\t/"       => '',
+        '/ +/'       => ' ',
+        '/> +</'     => '><',
+    ];
+
+    protected $_ignoreElements = [
+        'pre',
+        'textarea',
+        'style',
+        'script'
+    ];
+
+    /** @var string[][] */
+    protected $skippedElements = [];
+
+    /** @var string */
+    protected $key;
+
+    /**
+     * CollapseWhitespace constructor
+     */
+    public function __construct()
+    {
+        $this->key = md5(random_int(0, 100) . date('d.m.Y H:i:s')) . '-';
+    }
+
+    /**
+     * Apply replacement
+     *
+     * @param string $buffer
+     * @return string
+     */
     public function apply($buffer)
     {
-        $replace = [
-            "/\n([\S])/" => '$1',
-            "/\r/" => '',
-            "/\n/" => '',
-            "/\t/" => '',
-            "/ +/" => ' ',
-            "/> +</" => '><',
-        ];
+        $buffer = $this->preReplaceChange($buffer);
 
-        return $this->replace($replace, $buffer);
+        $buffer = $this->replace(self::REPLACEMENT, $buffer);
+
+        $buffer = $this->postReplaceChange($buffer);
+
+        return $buffer;
     }
+
+    /**
+     * Perform pre-replace changes
+     *
+     * @param string $buffer
+     * @return string
+     */
+    protected function preReplaceChange($buffer)
+    {
+        foreach($this->_ignoreElements as $element){
+            $buffer = $this->prepare($buffer, $element);
+        }
+
+        return $buffer;
+    }
+
+    /**
+     * Perform post-replace changes
+     *
+     * @param string $buffer
+     * @return string
+     */
+    protected function postReplaceChange($buffer)
+    {
+        foreach($this->_ignoreElements as $element){
+            $buffer = $this->recover($buffer, $element);
+        }
+        return $buffer;
+    }
+
+    /**
+     * Cut <textarea> content to prevent minification
+     *
+     * @param string $buffer
+     * @param string $element
+     *
+     * @return string
+     */
+    protected function prepare($buffer, $element)
+    {
+        preg_match_all("#\<{$element}.*\>.*\<\/{$element}\>#Uis", $buffer, $foundTxt);
+
+        $this->skippedElements[$element] = isset($foundTxt[0])? $foundTxt[0] : [];
+
+        return str_replace(
+            $this->skippedElements[$element],
+            array_map(function ($el) use($element) {
+                return "<{$element}>{$this->key}{$el}</{$element}>";
+            }, array_keys($this->skippedElements[$element])),
+            $buffer
+        );
+    }
+
+    /**
+     * Revert original <textarea> content to view
+     *
+     * @param string $buffer
+     * @param string $element
+     *
+     * @return string
+     */
+    protected function recover($buffer, $element)
+    {
+        return str_replace(
+            array_map(function ($el) use($element) {
+                return "<{$element}>{$this->key}{$el}</{$element}>";
+            }, array_keys($this->skippedElements[$element])),
+            $this->skippedElements[$element],
+            $buffer
+        );
+    }
+
 }


### PR DESCRIPTION
## Description

Middleware CollapseWhitespaces trim whitespaces and new lines inside HTML elements it should not touch and thus it is breaking functionality, even perhaps entire sites.

## Motivation and context

We have inline JS, CSS and use pre and textarea. Inline JS for example is in our page layout so there is no option to skip a route - it would mean skipping everything. As such there needs to be a way to skip HTML elements whose content you shouldn't be modifying.
This is only a continuation of the fork by SergeyPodgornyy (https://github.com/renatomarinho/laravel-page-speed/pull/81) which does not address all the HTML elements that need skipping. This adds some missing ones and modifies the code so that other HTML elements can be added as well if you need more skipped.

## How has this been tested?

So far testing in our own production site. I know my PR won't be accepted without tests, which I am unsure how to do. 

## Screenshots
![image](https://user-images.githubusercontent.com/5530603/49689411-7467f100-fb29-11e8-9b2a-5ee9419176b6.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.