### PR TITLE
Issue #97 - Always exclude StreamedResponse

### DIFF
--- a/src/Middleware/PageSpeed.php
+++ b/src/Middleware/PageSpeed.php
@@ -3,6 +3,7 @@
 namespace RenatoMarinho\LaravelPageSpeed\Middleware;
 
 use Closure;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 abstract class PageSpeed
@@ -77,6 +78,10 @@ abstract class PageSpeed
 
         if ($response instanceof BinaryFileResponse) {
             return false;
+        }
+
+        if ($response instanceof StreamedResponse) {
+           return false;
         }
 
         foreach ($patterns as $pattern) {

--- a/tests/Middleware/CollapseWhitespaceTest.php
+++ b/tests/Middleware/CollapseWhitespaceTest.php
@@ -2,21 +2,11 @@
 
 namespace RenatoMarinho\LaravelPageSpeed\Test\Middleware;
 
-use Illuminate\Http\Request;
-use Mockery as m;
-use RenatoMarinho\LaravelPageSpeed\Middleware\CollapseWhitespace;
 use RenatoMarinho\LaravelPageSpeed\Test\TestCase;
-use Symfony\Component\HttpFoundation\BinaryFileResponse;
-use Symfony\Component\HttpFoundation\File\UploadedFile;
+use RenatoMarinho\LaravelPageSpeed\Middleware\CollapseWhitespace;
 
 class CollapseWhitespaceTest extends TestCase
 {
-    public function tearDown()
-    {
-        parent::tearDown();
-        m::close();
-    }
-
     protected function getMiddleware()
     {
         $this->middleware = new CollapseWhitespace();
@@ -30,35 +20,5 @@ class CollapseWhitespaceTest extends TestCase
         $compress = '<!DOCTYPE html><!--[if IE 8]><html lang="en" class="ie8 no-js"><![endif]--><!--[if IE 9]><html lang="en" class="ie9 no-js"><![endif]--><!--[if !IE]><!--><html lang="en"><!--<![endif]--><head><meta charset="utf-8"><meta http-equiv="x-ua-compatible" content="ie=edge">';
 
         $this->assertSame($compress, trim($partial[0]));
-    }
-
-    public function testSkipBinaryFileResponse()
-    {
-        $request = Request::create('/', 'GET', [], [], ['file' => new UploadedFile(__FILE__, 'foo.php')]);
-
-        $response = $this->middleware->handle($request, function ($request) {
-            return response()->download($request->file);
-        });
-
-        $this->assertInstanceOf(BinaryFileResponse::class, $response);
-    }
-
-    public function testExpectLogicExceptionInBinaryFileResponse()
-    {
-        $this->expectException('LogicException');
-
-        $mock = m::mock(CollapseWhitespace::class)
-                    ->shouldAllowMockingProtectedMethods()
-                    ->makePartial();
-
-        $mock->shouldReceive('shouldProcessPageSpeed')
-            ->once()
-            ->andReturn(true);
-
-        $request = Request::create('/', 'GET', [], [], ['file' => new UploadedFile(__FILE__, 'foo.php')]);
-
-        $response = $mock->handle($request, function ($request) {
-            return response()->download($request->file);
-        });
     }
 }

--- a/tests/Middleware/ShouldNotProcessResponseTest.php
+++ b/tests/Middleware/ShouldNotProcessResponseTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace RenatoMarinho\LaravelPageSpeed\Test\Middleware;
+
+use RenatoMarinho\LaravelPageSpeed\Test\TestCase;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use RenatoMarinho\LaravelPageSpeed\Middleware\RemoveQuotes;
+
+class ShouldNotProcessResponseTest extends TestCase
+{
+    protected function getMiddleware()
+    {
+        $this->middleware = new RemoveQuotes();
+    }
+
+    /**
+     * Test that a StreamedResponse is ignored by middleware.
+     *
+     * @return void
+     */
+    public function testAStreamedResponseWithRemoveQuotesMiddleware()
+    {
+        $response = $this->middleware->handle($this->request, $this->getNext());
+
+        $this->assertInstanceOf(StreamedResponse::class, $response);
+    }
+
+    /**
+     * Get next response.
+     *
+     * @return \Closure
+     */
+    protected function getNext()
+    {
+        $response =  (new StreamedResponse(function () {
+            echo "I am Streamed";
+        }));
+
+        $response->headers->set('Content-Disposition', $response->headers->makeDisposition(
+            'attachment',
+            'foo.txt'
+        ));
+
+        return function ($request) use ($response) {
+            return $response;
+        };
+    }
+}


### PR DESCRIPTION
- Always exclude StreamedResponse similar to BinaryFileResponse as it cannot be handled.

<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR is a fix for the issue #97. It Checks the Response to see if it's and instance of StreamedResponse before allowing application of Page Speed very much so as BinaryFileResponse.

## Motivation and context

In my App I had a lot of routes which dealt with StreamedReponses, and having to exclude them one by one was a real pain. As we know that StreamedResponse won't be handled similar to BinaryFileResponse this motivated this PR.

fixes #97 

## How has this been tested?

I created a test which tried to pass a StreamedResponse to the Middleware. As expected it failed with message

```
LogicException: The content cannot be set on a StreamedResponse instance.
```
![image](https://user-images.githubusercontent.com/11259669/51817198-28dcf280-22e3-11e9-852b-5b526e8b48bd.png)

I then added my edit to the PageSpeed middleware and ran my tests again which it passed.

![image](https://user-images.githubusercontent.com/11259669/51817459-4199d800-22e4-11e9-8930-046b7a162e58.png)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
