### PR TITLE
Add Laravel 5.8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   ],
   "require": {
     "php": "^5.6 || ^7.0",
-    "illuminate/support": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8"
+    "illuminate/support": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.*"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.7 || ^6.0",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   ],
   "require": {
     "php": "^5.6 || ^7.0",
-    "illuminate/support": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.*"
+    "illuminate/support": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.7 || ^6.0",


### PR DESCRIPTION
## Description

I add the support for Laravel 5.8, I did check the source code and didn't found any incompatibility.

## Motivation and context

This adds support for Laravel 5.8, close #102 

## How has this been tested?

I didn't found tests for multiple Laravel version so didn't add it here.
