### PR TITLE
Remove new lines added by InsertDNSPrefetch

### DIFF
--- a/src/Middleware/InsertDNSPrefetch.php
+++ b/src/Middleware/InsertDNSPrefetch.php
@@ -22,10 +22,10 @@ class InsertDNSPrefetch extends PageSpeed
             );
 
             return "<link rel=\"dns-prefetch\" href=\"//{$domain[0]}\">";
-        })->unique()->implode("\n");
+        })->unique()->implode("");
 
         $replace = [
-            '#<head>(.*?)#' => "<head>\n{$dnsPrefetch}"
+            '#<head>(.*?)#' => "<head>{$dnsPrefetch}"
         ];
 
         return $this->replace($replace, $buffer);


### PR DESCRIPTION
## Description
This PR will remove new lines that are added by the InsertDNSPrefetch middleware.

## Motivation and context
Minified HTML is now on 1 single line only.

## How has this been tested?
Tested local & production, non-breaking changes.
