### PR TITLE
Fix remove quotes when attributes contains whitespaces

### DIFF
--- a/src/Middleware/RemoveQuotes.php
+++ b/src/Middleware/RemoveQuotes.php
@@ -7,15 +7,15 @@ class RemoveQuotes extends PageSpeed
     public function apply($buffer)
     {
         $replace = [
-            '/ src="(.*?)"/' => ' src=$1',
-            '/ width="(.*?)"/' => ' width=$1',
-            '/ height="(.*?)"/' => ' height=$1',
-            '/ name="(.*?)"/' => ' name=$1',
-            '/ charset="(.*?)"/' => ' charset=$1',
-            '/ align="(.*?)"/' => ' align=$1',
-            '/ border="(.*?)"/' => ' border=$1',
-            '/ crossorigin="(.*?)"/' => ' crossorigin=$1',
-            '/ type="(.*?)"/' => ' type=$1',
+            '/ src="(.\S*?)"/' => ' src=$1',
+            '/ width="(.\S*?)"/' => ' width=$1',
+            '/ height="(.\S*?)"/' => ' height=$1',
+            '/ name="(.\S*?)"/' => ' name=$1',
+            '/ charset="(.\S*?)"/' => ' charset=$1',
+            '/ align="(.\S*?)"/' => ' align=$1',
+            '/ border="(.\S*?)"/' => ' border=$1',
+            '/ crossorigin="(.\S*?)"/' => ' crossorigin=$1',
+            '/ type="(.\S*?)"/' => ' type=$1',
             '/\/>/' => '>',
         ];
 

--- a/tests/Boilerplate/index.html
+++ b/tests/Boilerplate/index.html
@@ -30,11 +30,15 @@
         </div>
         <img src="http://emblemsbf.com/img/18346.jpg" width="250" style="height:300px; padding:10px" />
 
+        <img src="tile whitespace.png" width="250" style="height:300px; padding:10px"/>
+
         <form method="get" class="form" style="display:block;border:1px solid red;">
 
             <input type="text" disabled="true" value="teste" width="100%">
             <input type="text" disabled="true">
             <input style="border:1px solid red" type="text" disabled=true>
+
+            <input type="text" name="name with spaces" value="name with spaces" width="100%">
 
             <select style="height:300px; padding:10px">
                 <option selected="selected" class="selected" style="cursor: default">Item</option>

--- a/tests/Middleware/RemoveQuotesTest.php
+++ b/tests/Middleware/RemoveQuotesTest.php
@@ -22,5 +22,7 @@ class RemoveQuotesTest extends TestCase
         $this->assertContains('<img src=http://emblemsbf.com/img/18346.jpg width=250 style="height:300px; padding:10px" >', $response->getContent());
         $this->assertContains('<img src=/images/1000coin.png>', $response->getContent());
         $this->assertContains('<vue-component :src="\'src\'" :type="\'type\'" :width="200"></vue-component>', $response->getContent());
+        $this->assertContains('<img src="tile whitespace.png" width=250 style="height:300px; padding:10px">', $response->getContent());
+        $this->assertContains('<input type=text name="name with spaces" value="name with spaces" width=100%>', $response->getContent());
     }
 }


### PR DESCRIPTION
## Description
RemoveQuotes middleware isn't checking if contains whitespaces inside the attribute before removing quotes. This can crash images `src` or input `name`.

## Motivation and context

Fixes #105.

## How has this been tested?

Running tests and being able to render an image with whitespace on the path with the `RemoveQuotes` middleware.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.