### PR TITLE
[2.x] Fix remove comments html context

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0",
     "orchestra/testbench": "^3.5 || ^4.0 || ^5.0",
     "squizlabs/php_codesniffer": "^3.4",
-    "mockery/mockery": "^1.2"
+    "mockery/mockery": "^1.3"
   },
   "autoload": {
     "psr-4": {

--- a/src/Middleware/PageSpeed.php
+++ b/src/Middleware/PageSpeed.php
@@ -92,4 +92,43 @@ abstract class PageSpeed
 
         return true;
     }
+
+    /**
+     * Match all occurrences of the html tags given
+     *
+     * @param array  $tags   Html tags to match in the given buffer
+     * @param string $buffer Middleware response buffer
+     *
+     * @return array $matches Html tags found in the buffer
+     */
+    protected function matchAllHtmlTag(array $tags, string $buffer): array
+    {
+        $tags = '('.implode('|', $tags).')';
+
+        preg_match_all("/\<\s*{$tags}[^>]*\>((.|\n)*?)\<\s*\/\s*{$tags}\>/", $buffer, $matches);
+        return $matches;
+    }
+
+    /**
+     * Replace occurrences of regex pattern inside of given HTML tags
+     *
+     * @param array  $tags    Html tags to match and run regex to replace occurrences
+     * @param string $regex   Regex rule to match on the given HTML tags
+     * @param string $replace Content to replace
+     * @param string $buffer  Middleware response buffer
+     *
+     * @return string $buffer Middleware response buffer
+     */
+    protected function replaceInsideHtmlTags(array $tags, string $regex, string $replace, string $buffer): string
+    {
+        foreach ($this->matchAllHtmlTag($tags, $buffer)[0] as $tagMatched) {
+            preg_match_all($regex, $tagMatched, $tagContentsMatchedToReplace);
+
+            foreach ($tagContentsMatchedToReplace[0] as $tagContentReplace) {
+                $buffer = str_replace($tagContentReplace, $replace, $buffer);
+            }
+        }
+
+        return $buffer;
+    }
 }

--- a/src/Middleware/RemoveComments.php
+++ b/src/Middleware/RemoveComments.php
@@ -4,13 +4,17 @@ namespace RenatoMarinho\LaravelPageSpeed\Middleware;
 
 class RemoveComments extends PageSpeed
 {
+    const REGEX_MATCH_JS_AND_CSS_COMMENTS = '/(?:(?:\/\*(?:[^*]|(?:\*+[^*\/]))*\*+\/)|(?:(?<!\:|\\\|\'|\")\/\/.*))/';
+    const REGEX_MATCH_HTML_COMMENTS = '/<!--[^]><!\[](.*?)[^\]]-->/s';
+
     public function apply($buffer)
     {
-        $replace = [
-            '/<!--[^]><!\[](.*?)[^\]]-->/s' => '',
-            '/(?:(?:\/\*(?:[^*]|(?:\*+[^*\/]))*\*+\/)|(?:(?<!\:|\\\|\'|\")\/\/.*))/' => '',
+        $buffer = $this->replaceInsideHtmlTags(['script', 'style'], self::REGEX_MATCH_JS_AND_CSS_COMMENTS, '', $buffer);
+
+        $replaceHtmlRules = [
+            self::REGEX_MATCH_HTML_COMMENTS => '',
         ];
 
-        return $this->replace($replace, $buffer);
+        return $this->replace($replaceHtmlRules, $buffer);
     }
 }

--- a/tests/Boilerplate/index.html
+++ b/tests/Boilerplate/index.html
@@ -35,6 +35,9 @@
 
         <!-- Add your site or application content here -->
         <p>Hello world! This is HTML5 Boilerplate.</p>
+
+        <p>Hello! I am /* not a comment */ at HTML context!</p>
+        <p>Hello! I am // not a comment at HTML context!</p>
         <div style="background-image: url('img/test-bg.jpg');">
             <h1>Test Background Image</h1>
         </div>

--- a/tests/Middleware/RemoveCommentsTest.php
+++ b/tests/Middleware/RemoveCommentsTest.php
@@ -64,6 +64,16 @@ class RemoveCommentsTest extends TestCase
         <![endif]-->",
             $this->response->getContent()
         );
+
+        $this->assertStringContainsString(
+            "<p>Hello! I am /* not a comment */ at HTML context!</p>",
+            $this->response->getContent()
+        );
+
+        $this->assertStringContainsString(
+            "<p>Hello! I am // not a comment at HTML context!</p>",
+            $this->response->getContent()
+        );
     }
 
     public function testRemoveCssComments()


### PR DESCRIPTION
## Description
This fixes the bug of removing js and css comments characters at html context from PR https://github.com/renatomarinho/laravel-page-speed/pull/111

I first made a regex to find script tags and inside of them find only comments, but I had to use positive lookbehind and PHP supports it only with fixed length, what is not the case I needed to fix this bug.

So I’ve brought another solution to this bug, which implies of finding script and style tags and removing theirs comments only inside of their scopes.

## Motivation and context

This PR fixes a bug raised in a code review from PR https://github.com/renatomarinho/laravel-page-speed/pull/111.

## How has this been tested?

Running project unit tests and testing pages on browser that broke PR https://github.com/renatomarinho/laravel-page-speed/pull/111.

## Screenshots (if appropriate)
HTML Code
<img width="298" alt="Screen Shot 2020-02-15 at 20 20 47" src="https://user-images.githubusercontent.com/42281497/74596646-cb702c80-5030-11ea-8b50-d98becdc42f5.png">

HTML after browser rendered
<img width="265" alt="Screen Shot 2020-02-15 at 20 21 14" src="https://user-images.githubusercontent.com/42281497/74596649-cf9c4a00-5030-11ea-8ea1-0c7514791994.png">

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Fixes a bug onto another PR

## Checklist:
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
