### PR TITLE
[2.x] Optimize package enabled verification

### DIFF
--- a/src/Middleware/PageSpeed.php
+++ b/src/Middleware/PageSpeed.php
@@ -8,6 +8,8 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 abstract class PageSpeed
 {
+    protected static $isEnabled;
+
     /**
      * Apply rules.
      *
@@ -56,8 +58,13 @@ abstract class PageSpeed
      */
     protected function isEnable()
     {
-        $enable = config('laravel-page-speed.enable');
-        return (is_null($enable))?true: (boolean) $enable;
+        if (! is_null(static::$isEnabled)) {
+            return static::$isEnabled;
+        }
+
+        static::$isEnabled = (bool) config('laravel-page-speed.enable', true);
+
+        return static::$isEnabled;
     }
 
     /**

--- a/src/Middleware/PageSpeed.php
+++ b/src/Middleware/PageSpeed.php
@@ -88,8 +88,7 @@ abstract class PageSpeed
            return false;
         }
 
-        $patterns = config('laravel-page-speed.skip');
-        $patterns = is_null($patterns) ? [] : $patterns;
+        $patterns = config('laravel-page-speed.skip', []);
 
         foreach ($patterns as $pattern) {
             if ($request->is($pattern)) {

--- a/src/Middleware/PageSpeed.php
+++ b/src/Middleware/PageSpeed.php
@@ -76,9 +76,6 @@ abstract class PageSpeed
      */
     protected function shouldProcessPageSpeed($request, $response)
     {
-        $patterns = config('laravel-page-speed.skip');
-        $patterns = (is_null($patterns))?[]: $patterns;
-
         if (! $this->isEnable()) {
             return false;
         }
@@ -90,6 +87,9 @@ abstract class PageSpeed
         if ($response instanceof StreamedResponse) {
            return false;
         }
+
+        $patterns = config('laravel-page-speed.skip');
+        $patterns = is_null($patterns) ? [] : $patterns;
 
         foreach ($patterns as $pattern) {
             if ($request->is($pattern)) {

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -90,6 +90,17 @@ class ConfigTest extends TestCase
         $this->assertNotEquals($this->html, $response->getContent());
     }
 
+    public function testWontReadEnableConfigMoreThanOnce()
+    {
+        $pageSpeed = m::mock(TrimUrls::class)
+                        ->shouldAllowMockingProtectedMethods()
+                        ->makePartial();
+
+        config(['laravel-page-speed.enable' => false]);
+
+        $this->assertTrue($pageSpeed->isEnable());
+    }
+
     protected function mockMiddlewareWithEnableNull()
     {
         $mock = m::mock(TrimUrls::class)


### PR DESCRIPTION
## Description

PageSpeed middleware is getting called for each middleware, doing the check for each enabled feature. 

## Motivation and context

This PR caches the config enabled verification, so it will be verified only once.
This problem was mentioned at issue #40 and #76 

## Types of changes
- [x] Performance Optimization