### PR TITLE
check for skipped request parameters

### DIFF
--- a/src/Middleware/PageSpeed.php
+++ b/src/Middleware/PageSpeed.php
@@ -94,6 +94,9 @@ abstract class PageSpeed
             if ($request->is($pattern)) {
                 return false;
             }
+            if ($request->has($pattern)) {
+                return false;
+            }
         }
 
         return true;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Check for skipped parameter request

## Motivation and context

I had a challenge on Google AMP pages when parameter defer is added to scripts, which results to AMP error. I tried to add parameters on skip like '?amp=1','*?amp=1','?amp*' where neither would work.


## How has this been tested?
I have tested on a news site https://www.standardmedia.co.ke/entertainment/fashion-and-style/2001409537/best-dressed-at-the-bafta-awards-2021 where when parameter amp is set it escapes laravel pagespeed.



