### PR TITLE
Decouple API security headers from PageSpeed processing

### DIFF
--- a/src/Middleware/ApiSecurityHeaders.php
+++ b/src/Middleware/ApiSecurityHeaders.php
@@ -125,11 +125,6 @@ class ApiSecurityHeaders extends PageSpeed
      */
     protected function shouldAddSecurityHeaders($request, $response)
     {
-        // Check if middleware is enabled
-        if (! $this->shouldProcessPageSpeed($request, $response)) {
-            return false;
-        }
-
         // Add to all API responses
         $contentType = $response->headers->get('Content-Type', '');
 


### PR DESCRIPTION
## Description

This PR removes the dependency between the API security headers middleware and the PageSpeed processing logic.

`ApiSecurityHeaders` should only be responsible for adding security-related HTTP headers and should not be gated by PageSpeed enable/disable rules. The middleware now applies headers solely based on the response content type.

---

## Motivation and context

Security headers must be applied consistently and independently of performance-related middleware.

Previously, API security headers were skipped whenever PageSpeed processing was disabled or excluded for a request, which could unintentionally weaken the security posture of API responses. This change fixes that coupling and ensures security headers are always applied to eligible API responses.

---

## How has this been tested?

Manually verified by:
- Making API requests returning `application/json`
- Confirming security headers are present even when PageSpeed processing is disabled or excluded
- Ensuring no headers are duplicated when already set

No existing behavior for PageSpeed HTML processing is affected.

---

## Screenshots (if appropriate)

N/A

---

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.
