### PR TITLE
Fix: Prevent PCRE stack exhaustion and blank pages in replaceInsideHtmlTags

### DIFF
--- a/src/Middleware/PageSpeed.php
+++ b/src/Middleware/PageSpeed.php
@@ -210,17 +210,24 @@ abstract class PageSpeed
 
         // Pattern for normal tags
         if (!empty($normalTags)) {
-            $normalPattern = '/\<\s*(' . implode('|', $normalTags) . ')[^>]*\>((.|\n)*?)\<\s*\/\s*\1\>/i';
+            // OPTIMIZATION 1: Use .*? and the modifier 's' (PCRE_DOTALL)
+            // This allows dot to capture line breaks without creating nested groups.
+            // It is dozens of times faster and does not clog the PCRE stack.
+            $normalPattern = '/\<\s*(' . implode('|', $normalTags) . ')[^>]*\>.*?\<\s*\/\s*\1\>/is';
             $patterns[] = $normalPattern;
         }
 
-        // Performance: Use preg_replace_callback for single-pass processing
-        // This is much faster than iterating and doing multiple str_replace on the entire buffer
         foreach ($patterns as $pattern) {
-            $buffer = preg_replace_callback($pattern, function ($matches) use ($regex, $replace) {
-                // Apply the regex replacement only within this tag
-                return preg_replace($regex, $replace, $matches[0]);
+            $result = preg_replace_callback($pattern, function ($matches) use ($regex, $replace) {
+                // OPTIMIZATION 2: Protection from internal error.
+                // If deleting comments inside the tag failed (returned null),
+                // we simply return the original content of the tag, rather than breaking the entire page.
+                return preg_replace($regex, $replace, $matches[0]) ?? $matches[0];
             }, $buffer);
+
+            // OPTIMIZATION 3: Protection from external error.
+            // If the search for the <script> tags themselves has dropped, we leave the entire buffer unchanged.
+            $buffer = $result ?? $buffer;
         }
 
         return $buffer;

--- a/src/Middleware/PageSpeed.php
+++ b/src/Middleware/PageSpeed.php
@@ -216,7 +216,9 @@ abstract class PageSpeed
             $normalPattern = '/\<\s*(' . implode('|', $normalTags) . ')[^>]*\>.*?\<\s*\/\s*\1\>/is';
             $patterns[] = $normalPattern;
         }
-
+        
+        // Performance: Use preg_replace_callback for single-pass processing
+        // This is much faster than iterating and doing multiple str_replace on the entire buffer
         foreach ($patterns as $pattern) {
             $result = preg_replace_callback($pattern, function ($matches) use ($regex, $replace) {
                 // OPTIMIZATION 2: Protection from internal error.


### PR DESCRIPTION
This fixes a critical issue where the `replaceInsideHtmlTags` method causes a `TypeError` (returning `null` instead of a string) and results in a completely blank page for the user (or a 500 Error). 

This happens when processing very large tags (e.g., `<script type="application/ld+json">` with thousands of characters). The PCRE engine hits the `pcre.backtrack_limit` or JIT stack limit, causing `preg_replace` to fail and return `null`, which previously wiped the entire `$buffer`.

### Changes Made
1. **Regex Optimization:** Replaced the `((.|\n)*?)` capturing group with `.*?` and the `s` (PCRE_DOTALL) modifier. This prevents catastrophic backtracking, does not clog the PCRE stack, and improves processing speed significantly.
2. **Internal Error Protection:** Added `?? $matches[0]` inside the callback. If removing comments inside a specific tag fails due to limits, it will gracefully return the original tag content rather than breaking the page.
3. **External Error Protection:** Added `$buffer = $result ?? $buffer;`. If the main `preg_replace_callback` fails, the entire page buffer is preserved instead of being overwritten with `null`.

### Impact
- Eliminates 500 errors / white screens on pages with large `<script>` or `<style>` blocks.
- Drastically improves regex performance during HTML minification.
- Makes the middleware completely fault-tolerant to PCRE engine limits.